### PR TITLE
Fix a flaky test by cleaning a polluted state.

### DIFF
--- a/tests/test_propagation_logger.py
+++ b/tests/test_propagation_logger.py
@@ -97,6 +97,7 @@ def test_forcing_level_with_kwargs_by_level(propagation_logger, handler):
 
 
 def test_forcing_level_by_dict(propagation_logger, handler):
+    propagation_logger.reset_level()
     msg1 = "TEST1"
     msg2 = "TEST2"
     propagation_logger.setLevel(logging.INFO)


### PR DESCRIPTION
# What is the purpose of the change
This PR is to fix a flaky test `tests/test_propagation_logger.py::test_forcing_level_by_dict`, which can fail after running `tests/test_propagation_logger.py::test_forcing_level_by_level_name`, but passes when run in isolation.

# Reproduce the test failure
Run the following command:
```
python -m pytest tests/test_propagation_logger.py::test_forcing_level_by_level_name tests/test_propagation_logger.py::test_forcing_level_by_dict
```
# Expected result
`tests/test_propagation_logger.py::test_forcing_level_by_dict` should pass after running `tests/test_propagation_logger.py::test_forcing_level_by_level_name`.

# Actual result
```
E           Failed: DID NOT RAISE <class 'IndexError'>

tests/test_propagation_logger.py:116: Failed
```
# Why it fails
`propagation_logger` is polluted after  running `tests/test_propagation_logger.py::test_forcing_level_by_level_name`.
# Fix
Reset `propagation_logger` at the beginning of `tests/test_propagation_logger.py::test_forcing_level_by_dict`
